### PR TITLE
Switch back to regex

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ const TEST_STRINGS = [
         """,
     "whitespace" => "a\nb\n c \nd\n",
     "no ending newline" => "foo",
+    "starting newline" => "\nbar",
 ]
 
 # Validate `yaml_block` function


### PR DESCRIPTION
Following up on https://github.com/invenia/MultilineStrings.jl/pull/1#issuecomment-684898922. I did some benchmarking of the `multiline` loop version versus the regex version. I noticed that depending on where newlines resided in the string the performance could change drastically. For example if there was a continuous sequence of newlines we would see better performance than if the same number of newlines were separated by another character (`regex-1` / `loop-1`). Therefore, to evaluate the algorithms properly I ended up generating strings with a varying amount of newlines where the newlines were placed every other character (`regex-2` / `loop-2`), every 3rd character (`regex-3` / `loop-3`), and so on. Using a string length of 100 I produced the following performance graph:

![fixed-100](https://user-images.githubusercontent.com/1675958/91900966-19fbb600-ec65-11ea-8096-fdfde776f01c.png)

Note as the number newlines increases eventually the newlines will form continuous groupings. The graph shows regular expression version has better performance when the number of newlines is low where as the loop version is less impacted by the composition of newlines in the string. I'll also note that I also examined strings of length 250, 500, and 1000 which generated graphs similar to the one above.

In general, it appears that if less than 15% of the string is comprised of newlines it is faster to use the regex over the loop implementation. That means if we expect less than 1 in 10 characters to be newlines we should use the regex version of the code. Since the primary use case of `multiline` is to process strings containing sentences we should see better performance using the regex version of the code.

Finally, I also examined using a heuristic to switch between the two algorithms but the cost of checking for the number of newlines contained within the string added additional overhead which reduces performance.